### PR TITLE
Add express server and OpenTelemetry tracing

### DIFF
--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -1,0 +1,14 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+
+exporters:
+  file:
+    path: ./otel-traces.json
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [file]

--- a/package.json
+++ b/package.json
@@ -7,10 +7,17 @@
     "extract": "ts-node src/index.ts"
   },
   "dependencies": {
-    "ts-morph": "^17.0.1"
+    "ts-morph": "^17.0.1",
+    "express": "^4.19.2",
+    "@opentelemetry/sdk-node": "^1.21.0",
+    "@opentelemetry/api": "^1.6.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.41.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^1.6.0",
+    "axios": "^1.6.7"
   },
   "devDependencies": {
     "typescript": "^5.0.0",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "@types/express": "^4.17.17"
   }
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,9 +1,15 @@
 export class User {
-  firstName!: string;
-  lastName!: string;
-  age!: number;
+  firstName: string;
+  lastName: string;
+  age: number;
   meta = {
     verified: false,
     region: "NA",
   };
+
+  constructor(firstName: string, lastName: string, age: number) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.age = age;
+  }
 }

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+(async () => {
+  const res = await axios.get('http://localhost:3000/user/1');
+  console.log('API Response:', res.data);
+})();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,19 @@
+import './tracing';
+import express from 'express';
+import { User } from './models/User';
+import { UserView } from './models/UserView';
+import { UserDisplay } from './models/UserDisplay';
+
+const app = express();
+const port = 3000;
+
+app.get('/user/:id', (req, res) => {
+  const user = new User('Alice', 'Smith', 28);
+  const view = new UserView(user);
+  const display = new UserDisplay(view);
+  res.json(display);
+});
+
+app.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -1,0 +1,14 @@
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter({
+    url: 'http://localhost:4318/v1/traces',
+  }),
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+sdk.start().then(() => {
+  console.log('Tracing initialized.');
+});


### PR DESCRIPTION
## Summary
- add express server exposing an example user API
- instrument with OpenTelemetry
- add a script to run synthetic traffic
- add configuration for an OTEL collector
- enhance `User` model with a constructor
- declare required dependencies

## Testing
- `npm install express @types/express` *(fails: 403 Forbidden)*
- `npm install @opentelemetry/sdk-node @opentelemetry/api @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-otlp-http` *(fails: 403 Forbidden)*
- `npm install axios` *(fails: 403 Forbidden)*
- `npx tsc --noEmit` *(fails to compile: missing modules)
- `npx ts-node src/runTests.ts` *(fails due to unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_684c58eaa2508332b947b7fa2307e3e3